### PR TITLE
Fix typo

### DIFF
--- a/ko/component-guide.md
+++ b/ko/component-guide.md
@@ -381,7 +381,7 @@ python $HOME/models/official/vision/image_classification/mnist_main.py \
   --download
 
 $ chmod +x train.sh
-$ python ./train.sh
+$ ./train.sh
 ```
 
 >[참고]
@@ -404,7 +404,7 @@ $ python ./train.sh
 $ cd ~/
 $ git clone https://github.com/pytorch/examples.git
 $ cd examples/mnist
-$ python manin.py --epochs 1
+$ python main.py --epochs 1
 ```
 
 >[참고]


### PR DESCRIPTION
Fix typo:

`$ python ./train.sh` -> `$ ./train.sh`
`$ python manin.py --epochs 1` -> `$ python main.py --epochs 1`